### PR TITLE
skipping parsing for commented lines in .mssqlpass

### DIFF
--- a/MessQL.sln
+++ b/MessQL.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessQL", "MessQL.csproj", "{04F50AF1-76A1-41CB-B918-B7535974A809}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{04F50AF1-76A1-41CB-B918-B7535974A809}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{04F50AF1-76A1-41CB-B918-B7535974A809}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{04F50AF1-76A1-41CB-B918-B7535974A809}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{04F50AF1-76A1-41CB-B918-B7535974A809}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AD5C81F1-3E2C-4327-8073-25D204C97AD7}
+	EndGlobalSection
+EndGlobal

--- a/Program.cs
+++ b/Program.cs
@@ -774,6 +774,12 @@ Connection
 		IList<Config> configs = new List<Config> ();
 
 		foreach (string line in configlines) {
+
+			// don't parse comments
+			if (line.StartsWith('#')) {
+				continue;
+			}
+
 			string[] parts = line.Split (':');
 
 			if (parts.Length != 5) {


### PR DESCRIPTION
any line starting with `#` in .mssqlpass should not be parsed as a connection